### PR TITLE
Fix admin link in profile to use configurable admin URL

### DIFF
--- a/flamerelay/static/js/AuthContext.tsx
+++ b/flamerelay/static/js/AuthContext.tsx
@@ -11,6 +11,7 @@ interface AuthUser {
   username: string;
   name: string;
   is_superuser: boolean;
+  admin_url: string | null;
 }
 
 interface AuthContextValue {
@@ -18,6 +19,7 @@ interface AuthContextValue {
   username: string;
   name: string;
   isSuperuser: boolean;
+  adminUrl: string | null;
   loading: boolean;
   refresh: () => Promise<void>;
 }
@@ -27,6 +29,7 @@ const AuthContext = createContext<AuthContextValue>({
   username: '',
   name: '',
   isSuperuser: false,
+  adminUrl: null,
   loading: true,
   refresh: async () => {},
 });
@@ -61,6 +64,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         username: user?.username ?? '',
         name: user?.name ?? '',
         isSuperuser: user?.is_superuser ?? false,
+        adminUrl: user?.admin_url ?? null,
         loading,
         refresh,
       }}

--- a/flamerelay/static/js/pages/UserDetail.tsx
+++ b/flamerelay/static/js/pages/UserDetail.tsx
@@ -15,7 +15,7 @@ function initials(name: string): string {
 }
 
 export default function UserDetail() {
-  const { username, name, isSuperuser } = useAuth();
+  const { username, name, isSuperuser, adminUrl } = useAuth();
   const [subscribedUnits, setSubscribedUnits] = useState<
     SubscribedUnit[] | null
   >(null);
@@ -49,9 +49,9 @@ export default function UserDetail() {
         >
           Settings
         </Link>
-        {isSuperuser && (
+        {isSuperuser && adminUrl && (
           <a
-            href="/admin/"
+            href={adminUrl}
             className="rounded-lg bg-char px-4 py-2 text-sm font-medium text-white hover:opacity-90"
           >
             Admin

--- a/flamerelay/users/api/serializers.py
+++ b/flamerelay/users/api/serializers.py
@@ -1,14 +1,22 @@
+from django.conf import settings
 from rest_framework import serializers
 
 from flamerelay.users.models import User
 
 
 class UserSerializer(serializers.ModelSerializer[User]):
+    admin_url = serializers.SerializerMethodField()
+
+    def get_admin_url(self, obj: User) -> str | None:
+        if obj.is_superuser:
+            return f"/{settings.ADMIN_URL}"
+        return None
+
     # pyrefly: ignore [bad-override]
     class Meta:
         model = User
-        fields = ["username", "name", "url", "is_superuser"]
-        read_only_fields = ["username", "is_superuser"]
+        fields = ["username", "name", "url", "is_superuser", "admin_url"]
+        read_only_fields = ["username", "is_superuser", "admin_url"]
 
         extra_kwargs = {
             "url": {"view_name": "api:user-detail", "lookup_field": "username"},

--- a/flamerelay/users/tests/api/test_views.py
+++ b/flamerelay/users/tests/api/test_views.py
@@ -39,4 +39,5 @@ class TestUserViewSet:
             "url": f"http://testserver/api/users/{user.username}/",
             "name": user.name,
             "is_superuser": False,
+            "admin_url": None,
         }


### PR DESCRIPTION
The admin URL is randomised in production via DJANGO_ADMIN_URL env var.
UserSerializer now returns admin_url (superusers only) via a method field;
AuthContext threads it through as adminUrl; UserDetail uses it instead of
the hardcoded /admin/ href.

https://claude.ai/code/session_01EvxVCoAvFzeyjvJ8GGtgLq