### PR TITLE
Add missing language field to account API test assertion

### DIFF
--- a/flamerelay/users/tests/api/test_views.py
+++ b/flamerelay/users/tests/api/test_views.py
@@ -28,6 +28,7 @@ class TestAccountView:
         assert response.data == {
             "username": user.username,
             "name": user.name,
+            "language": user.language,
             "admin_url": None,
         }
 


### PR DESCRIPTION
The UserSerializer now includes language in its response after the user
language preference feature was added, but the test_get assertion was
not updated to match.

https://claude.ai/code/session_01AwXBzvu6DvrkyfevXWXTr8