### PR TITLE
Fix CSRF cookie missing for anonymous users on guest email subscribe

### DIFF
--- a/flamerelay/users/views.py
+++ b/flamerelay/users/views.py
@@ -1,3 +1,4 @@
+from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import TemplateView
 
-spa_view = TemplateView.as_view(template_name="spa.html")
+spa_view = ensure_csrf_cookie(TemplateView.as_view(template_name="spa.html"))


### PR DESCRIPTION
spa_view was a bare TemplateView with no {% csrf_token %} in the template
and no @ensure_csrf_cookie decorator. Django only sets the CSRF cookie when
get_token() is called, so anonymous users never received the cookie. The
check-in POST succeeds because DRF APIViews are csrf_exempt, but
GuestSubscribeView manually calls SessionAuthentication().enforce_csrf(),
which rejected every anonymous guest email submission with 403.

https://claude.ai/code/session_017GuEnocM88bm1pPxPq48b2